### PR TITLE
fix: filtering commits by my name

### DIFF
--- a/src/workflows/-utils/github-graphql.test.ts
+++ b/src/workflows/-utils/github-graphql.test.ts
@@ -14,7 +14,6 @@ import {
   fetchRepoCommits,
   fetchRepoPRs,
   fetchUserRepos,
-  isAuthoredByUser,
   isPRAuthoredByUser,
 } from './github-graphql';
 
@@ -28,7 +27,6 @@ const mockRateLimitResponse = {
 const mockUserReposResponse = {
   rateLimit: mockRateLimitResponse,
   viewer: {
-    email: 'test@example.com',
     repositories: {
       nodes: [
         {
@@ -66,7 +64,7 @@ const mockCommitsResponse = {
               additions: 50,
               deletions: 10,
               changedFilesIfAvailable: 5,
-              author: { email: 'test@example.com' },
+              author: { user: { login: 'eve0415' } },
             },
           ],
           pageInfo: {
@@ -195,7 +193,6 @@ describe('fetchUserRepos', () => {
     const client = createGitHubClient('test-token');
     const result = await fetchUserRepos(client);
 
-    expect(result.data.viewer.email).toBe('test@example.com');
     expect(result.data.viewer.repositories.nodes).toHaveLength(1);
     expect(result.data.viewer.repositories.nodes?.[0]?.name).toBe('test-repo');
     expect(result.rateLimit.remaining).toBe(4500);
@@ -313,27 +310,6 @@ describe('calculateDynamicThreshold', () => {
     const threshold = calculateDynamicThreshold(DEFAULT_RATE_LIMIT_METRICS, 20, 10);
     // 10 remaining * 12 = 120
     expect(threshold).toBe(120);
-  });
-});
-
-describe('isAuthoredByUser', () => {
-  it('returns true for matching emails (case-insensitive)', () => {
-    expect(isAuthoredByUser('Test@Example.com', 'test@example.com')).toBe(true);
-    expect(isAuthoredByUser('test@example.com', 'TEST@EXAMPLE.COM')).toBe(true);
-  });
-
-  it('returns false for non-matching emails', () => {
-    expect(isAuthoredByUser('other@example.com', 'test@example.com')).toBe(false);
-  });
-
-  it('returns false when authorEmail is null or undefined', () => {
-    expect(isAuthoredByUser(null, 'test@example.com')).toBe(false);
-    expect(isAuthoredByUser(undefined, 'test@example.com')).toBe(false);
-  });
-
-  it('returns false when userEmail is null or undefined', () => {
-    expect(isAuthoredByUser('test@example.com', null)).toBe(false);
-    expect(isAuthoredByUser('test@example.com', undefined)).toBe(false);
   });
 });
 

--- a/src/workflows/-utils/github-graphql.ts
+++ b/src/workflows/-utils/github-graphql.ts
@@ -74,7 +74,6 @@ const USER_REPOS_QUERY = /* GraphQL */ `
       resetAt
     }
     viewer {
-      email
       repositories(first: 100, after: $cursor, ownerAffiliations: [OWNER, ORGANIZATION_MEMBER]) {
         nodes {
           id
@@ -121,7 +120,9 @@ const REPO_COMMITS_QUERY = /* GraphQL */ `
                 deletions
                 changedFilesIfAvailable
                 author {
-                  email
+                  user {
+                    login
+                  }
                 }
               }
               pageInfo {
@@ -277,13 +278,7 @@ export function calculateDynamicThreshold(metrics: RateLimitMetrics, totalRepos:
   return Math.max(50, Math.min(500, estimatedRequestsNeeded));
 }
 
-/** Check if a commit was authored by the target user */
-export function isAuthoredByUser(authorEmail: string | null | undefined, userEmail: string | null | undefined): boolean {
-  if (!authorEmail || !userEmail) return false;
-  return authorEmail.toLowerCase() === userEmail.toLowerCase();
-}
-
-/** Check if a PR/review was authored by the target user */
+/** Check if a PR/review/commit was authored by the target user */
 export function isPRAuthoredByUser(authorLogin: string | null | undefined): boolean {
   if (!authorLogin) return false;
   return authorLogin.toLowerCase() === GITHUB_USERNAME.toLowerCase();

--- a/src/workflows/-utils/skills-analysis.graphql
+++ b/src/workflows/-utils/skills-analysis.graphql
@@ -5,7 +5,6 @@ query UserRepos($cursor: String) {
     resetAt
   }
   viewer {
-    email
     repositories(first: 100, after: $cursor, ownerAffiliations: [OWNER, ORGANIZATION_MEMBER]) {
       nodes {
         id
@@ -50,7 +49,9 @@ query RepoCommits($owner: String!, $name: String!, $since: GitTimestamp, $cursor
               deletions
               changedFilesIfAvailable
               author {
-                email
+                user {
+                  login
+                }
               }
             }
             pageInfo {


### PR DESCRIPTION
This pull request updates the way user identity is handled in the skills analysis workflow, shifting from using email addresses to GitHub usernames (logins) for author matching. It removes all code related to user email, updates GraphQL queries and TypeScript types, and simplifies related logic and tests.

**User identification and filtering:**

* Replaces all usage of user email for author identification with GitHub username (`login`), both in commit and PR logic, updating the filtering checks in `skills-analysis.ts` and utility functions. The `isAuthoredByUser` function and all related code are removed in favor of `isPRAuthoredByUser`, which now covers commits as well. [[1]](diffhunk://#diff-6ba3f850d6e0ee81eb684a12b4fbda95350f6367b6efe717f7d1152052f4bee0L397-R389) [[2]](diffhunk://#diff-c8a160dd20f386ac8a2aeb4c4d8865e6979c447b11bfc7c4183cbbf15706b7b7L280-R281) [[3]](diffhunk://#diff-e5b00f5ce53d8f0f00aeb7dbb921dade238cf7d76134fdea9337c9989e08edeeL17) [[4]](diffhunk://#diff-6ba3f850d6e0ee81eb684a12b4fbda95350f6367b6efe717f7d1152052f4bee0L26)

**GraphQL query and schema updates:**

* Removes `email` fields from `USER_REPOS_QUERY` and `REPO_COMMITS_QUERY` in `github-graphql.ts` and corresponding `.graphql` files, replacing commit author email with `user { login }` for consistency. [[1]](diffhunk://#diff-c8a160dd20f386ac8a2aeb4c4d8865e6979c447b11bfc7c4183cbbf15706b7b7L77) [[2]](diffhunk://#diff-c8a160dd20f386ac8a2aeb4c4d8865e6979c447b11bfc7c4183cbbf15706b7b7L124-R125) [[3]](diffhunk://#diff-714b310df32b5280bf18c98d9a9a4f880f9e11ebcd3723646600fd3f558d2347L8) [[4]](diffhunk://#diff-714b310df32b5280bf18c98d9a9a4f880f9e11ebcd3723646600fd3f558d2347L53-R54)

**Type and state cleanup:**

* Removes `userEmail` from the `SyncState` interface and all related state management logic, as email is no longer used anywhere in the workflow. [[1]](diffhunk://#diff-6ba3f850d6e0ee81eb684a12b4fbda95350f6367b6efe717f7d1152052f4bee0L63) [[2]](diffhunk://#diff-6ba3f850d6e0ee81eb684a12b4fbda95350f6367b6efe717f7d1152052f4bee0L106-R104) [[3]](diffhunk://#diff-6ba3f850d6e0ee81eb684a12b4fbda95350f6367b6efe717f7d1152052f4bee0L264-L283)

**Test updates:**

* Updates tests to use `user.login` instead of `email` for author matching, removes all tests for the deleted `isAuthoredByUser` function, and updates mock data accordingly. [[1]](diffhunk://#diff-e5b00f5ce53d8f0f00aeb7dbb921dade238cf7d76134fdea9337c9989e08edeeL31) [[2]](diffhunk://#diff-e5b00f5ce53d8f0f00aeb7dbb921dade238cf7d76134fdea9337c9989e08edeeL69-R67) [[3]](diffhunk://#diff-e5b00f5ce53d8f0f00aeb7dbb921dade238cf7d76134fdea9337c9989e08edeeL198) [[4]](diffhunk://#diff-e5b00f5ce53d8f0f00aeb7dbb921dade238cf7d76134fdea9337c9989e08edeeL319-L339)

These changes ensure that user identification for commit and PR authorship is consistent, more robust, and compliant with privacy best practices by avoiding reliance on email addresses.