### PR TITLE
fix: email mime validation error

### DIFF
--- a/src/routes/link/-utils/contact-form.test.ts
+++ b/src/routes/link/-utils/contact-form.test.ts
@@ -271,16 +271,36 @@ describe('sendContactEmail', () => {
     await sendContactEmail(formData);
 
     expect(mockAddMessage).toHaveBeenCalledWith({
-      contentType: 'text/plain; charset=UTF-8',
+      contentType: 'text/plain',
       data: expect.stringContaining('Test User'),
     });
     expect(mockAddMessage).toHaveBeenCalledWith({
-      contentType: 'text/plain; charset=UTF-8',
+      contentType: 'text/plain',
       data: expect.stringContaining('test@example.com'),
     });
     expect(mockAddMessage).toHaveBeenCalledWith({
-      contentType: 'text/plain; charset=UTF-8',
+      contentType: 'text/plain',
       data: expect.stringContaining('Hello, this is my message.'),
+    });
+  });
+
+  test('handles Japanese characters in form fields', async () => {
+    const formData = {
+      name: '田中太郎',
+      email: 'tanaka@example.com',
+      message: 'こんにちは、お問い合わせです。よろしくお願いします。',
+    };
+
+    await sendContactEmail(formData);
+
+    expect(mockSetSubject).toHaveBeenCalledWith('[Contact] 田中太郎');
+    expect(mockAddMessage).toHaveBeenCalledWith({
+      contentType: 'text/plain',
+      data: expect.stringContaining('田中太郎'),
+    });
+    expect(mockAddMessage).toHaveBeenCalledWith({
+      contentType: 'text/plain',
+      data: expect.stringContaining('こんにちは、お問い合わせです。よろしくお願いします。'),
     });
   });
 
@@ -337,15 +357,15 @@ describe('sendContactEmail', () => {
 
     // Body should have trimmed values
     expect(mockAddMessage).toHaveBeenCalledWith({
-      contentType: 'text/plain; charset=UTF-8',
+      contentType: 'text/plain',
       data: expect.stringContaining('Padded Name'),
     });
     expect(mockAddMessage).toHaveBeenCalledWith({
-      contentType: 'text/plain; charset=UTF-8',
+      contentType: 'text/plain',
       data: expect.stringContaining('padded@example.com'),
     });
     expect(mockAddMessage).toHaveBeenCalledWith({
-      contentType: 'text/plain; charset=UTF-8',
+      contentType: 'text/plain',
       data: expect.stringContaining('Padded message'),
     });
   });

--- a/src/routes/link/-utils/contact-form.ts
+++ b/src/routes/link/-utils/contact-form.ts
@@ -132,7 +132,7 @@ export const sendContactEmail = createServerOnlyFn(async (formData: ContactFormD
 ${formData.message.trim()}`;
 
   msg.addMessage({
-    contentType: 'text/plain; charset=UTF-8',
+    contentType: 'text/plain',
     data: body,
   });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { devtools } from '@tanstack/devtools-vite';
 import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, esmExternalRequirePlugin } from 'vite';
 import devtoolsJson from 'vite-plugin-devtools-json';
 
 export default defineConfig({
@@ -40,6 +40,9 @@ export default defineConfig({
     browserEcho({
       injectHtml: false,
       stackMode: 'condensed',
+    }),
+    esmExternalRequirePlugin({
+      external: ['node:path', 'path'],
     }),
   ],
   build: {


### PR DESCRIPTION
This pull request focuses on two main areas: improving internationalization support in contact form tests and updating build configuration for better compatibility. The most significant changes include adding a test for Japanese characters in contact form submissions, standardizing the email message content type, and enhancing the Vite build setup to handle certain Node.js modules more gracefully.

**Contact form improvements:**

* Added a test to ensure the contact email form correctly handles Japanese characters in the name and message fields, improving internationalization support.
* Standardized the `contentType` for email messages from `'text/plain; charset=UTF-8'` to `'text/plain'` in both the implementation (`sendContactEmail`) and its tests, simplifying expectations and possibly improving compatibility. [[1]](diffhunk://#diff-ef8b3317130e6df86038e0b1b4a9881a8b7de3428a3a5a0fd3d91846799b1662L135-R135) [[2]](diffhunk://#diff-3a26e6abd42581689b8a842b03aa0c12518569bd0000b2e3980731d35bc19560L274-R306) [[3]](diffhunk://#diff-3a26e6abd42581689b8a842b03aa0c12518569bd0000b2e3980731d35bc19560L340-R368)

**Build configuration enhancements:**

* Added the `esmExternalRequirePlugin` to the Vite configuration, specifying `node:path` and `path` as externals to improve module resolution and compatibility with ESM/CJS environments. [[1]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL9-R9) [[2]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR44-R46)