### PR TITLE
feat: replace DevTool with cella on projects page

### DIFF
--- a/src/routes/projects/-components/ProjectCard/project-card.fixtures.tsx
+++ b/src/routes/projects/-components/ProjectCard/project-card.fixtures.tsx
@@ -40,6 +40,15 @@ export const featuredWithHighlight: Project = {
   highlightSub: 'downloads',
 };
 
+export const featuredHighlightOnly: Project = {
+  title: 'cella',
+  description: 'A featured project with a highlight badge but no sub text.',
+  tags: ['Rust', 'Devcontainer', 'CLI'],
+  links: [{ label: 'GitHub', url: 'https://github.com/example' }],
+  featured: true,
+  highlight: 'Rust',
+};
+
 export const minimalProject: Project = {
   title: 'Minimal',
   description: 'Just the basics.',

--- a/src/routes/projects/index.stories.tsx
+++ b/src/routes/projects/index.stories.tsx
@@ -23,16 +23,18 @@ const projects: Project[] = [
     featured: true,
   },
   {
+    title: 'cella',
+    description: 'AIエージェント時代のターミナルネイティブ devcontainer CLI。公式 CLI では未実装のポートフォワーディングや認証転送を単一バイナリで実現。',
+    tags: ['Rust', 'Devcontainer', 'CLI'],
+    links: [{ label: 'GitHub', url: 'https://github.com/eve0415/cella' }],
+    highlight: 'Rust',
+    featured: true,
+  },
+  {
     title: 'eve0415.net',
     description: 'このウェブサイト自体がポートフォリオ。TanStack Start + Tailwind CSS 4 で構築。',
     tags: ['TypeScript', 'React', 'Cloudflare'],
     links: [{ label: 'ソースコード', url: 'https://github.com/eve0415/website' }],
-  },
-  {
-    title: 'DevTool',
-    description: '開発者向け Discord Bot。各種ユーティリティ機能を提供。',
-    tags: ['TypeScript', 'Discord.js'],
-    links: [{ label: 'GitHub', url: 'https://github.com/eve0415/DevTool' }],
   },
 ];
 
@@ -115,7 +117,7 @@ export const Default = meta.story({
     await expect(canvas.getByText('Projects')).toBeInTheDocument();
     await expect(canvas.getByText('IFPatcher')).toBeInTheDocument();
     await expect(canvas.getByText('eve0415.net')).toBeInTheDocument();
-    await expect(canvas.getByText('DevTool')).toBeInTheDocument();
+    await expect(canvas.getByText('cella')).toBeInTheDocument();
     await expect(canvas.getByText('GitHub Activity')).toBeInTheDocument();
   },
 });

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -51,16 +51,18 @@ const projects: Project[] = [
     featured: true,
   },
   {
+    title: 'cella',
+    description: 'AIエージェント時代のターミナルネイティブ devcontainer CLI。公式 CLI では未実装のポートフォワーディングや認証転送を単一バイナリで実現。',
+    tags: ['Rust', 'Devcontainer', 'CLI'],
+    links: [{ label: 'GitHub', url: 'https://github.com/eve0415/cella' }],
+    highlight: 'Rust',
+    featured: true,
+  },
+  {
     title: 'eve0415.net',
     description: 'このウェブサイト自体がポートフォリオ。TanStack Start + Tailwind CSS 4 で構築。',
     tags: ['TypeScript', 'React', 'Cloudflare'],
     links: [{ label: 'ソースコード', url: 'https://github.com/eve0415/website' }],
-  },
-  {
-    title: 'DevTool',
-    description: '開発者向け Discord Bot。各種ユーティリティ機能を提供。',
-    tags: ['TypeScript', 'Discord.js'],
-    links: [{ label: 'GitHub', url: 'https://github.com/eve0415/DevTool' }],
   },
 ];
 


### PR DESCRIPTION
## Summary

- Replace DevTool (Discord bot) with [cella](https://github.com/eve0415/cella) — a Rust devcontainer CLI for AI agents
- cella is featured with a "Rust" highlight badge
- Project order: IFPatcher → cella → eve0415.net
- Add `featuredHighlightOnly` test fixture for the new highlight-only pattern

## Test plan

- [x] `vp lint` passes
- [x] All 1451 tests pass
- [x] No DevTool project remnants in source
- [x] Visual check: projects page renders 2 featured cards + 1 standard + placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)